### PR TITLE
F1 userclass

### DIFF
--- a/assets/xslt/convert.xsl
+++ b/assets/xslt/convert.xsl
@@ -6,6 +6,7 @@
 
 	<xsl:template match="/">
 	  <HTML>
+	    <HEAD><link rel="stylesheet" type="text/css" href="../iconlog.css" /></HEAD>
 	  	<BODY>
 	  		<h2><xsl:value-of select="$imgbasepath" /></h2>
 	  		<xsl:apply-templates/>
@@ -16,7 +17,7 @@
 	<xsl:template match="chat-tab-list">
 
 		<TABLE border="1">
-			<tr> <th>tab</th> <th>name</th> <th>image</th> <th>message</th> <th>timestamp</th> </tr>
+			<tr> <th>tab</th> <th>name</th> <th>image</th> <th>message</th> <th>timestamp</th>  <th>from</th> </tr>
 			<xsl:apply-templates select="chat-tab/chat">
 					<xsl:sort select="@timestamp" data-type="number" order="ascending"/>
 			</xsl:apply-templates>
@@ -26,8 +27,7 @@
 	<xsl:template match="chat-tab/chat">
 		<xsl:choose>
 			<xsl:when test="../@name=$tabname or $tabname='+z4%H3(Ve84m'">
-				<tr> 
-					<td><xsl:value-of select="../@name"/></td>
+				<tr><td><xsl:value-of select="../@name"/></td>
 					<td><xsl:value-of select="@name"/></td> 
 					<td>
 						<img width="50px"> 
@@ -39,8 +39,18 @@
 							</xsl:attribute>
 						</img>
 					</td> 
-					<td><xsl:value-of select="."/></td>
+					<td>
+						<xsl:attribute name="class">
+							<xsl:value-of select="@from"/>
+						</xsl:attribute>
+						<xsl:value-of select="."/>
+					</td>
 					<td><xsl:value-of select="@timestamp"/></td> 
+					<td>
+						<xsl:attribute name="class">
+							<xsl:value-of select="@from"/>
+						</xsl:attribute>
+						<xsl:value-of select="@from"/></td> 
 				</tr>
 			</xsl:when>
 		</xsl:choose>

--- a/iconlog.css
+++ b/iconlog.css
@@ -1,0 +1,19 @@
+/* ユーザID毎に発言のスタイルを変更するCSSのサンプル */
+td {font-size:xx-small;}
+
+.System-BCDice 
+{ color: #333333; font-size:medium; }
+
+#user1,
+.abcdefgh, .ijklmno 
+{ color:#0d3964;
+  font-size:medium; 
+  word-wrap: break-word;
+  word-break: break-all;}
+
+#uesr2,
+.pqrstuvw
+{ color:#285a0f;
+    font-size:medium; 
+    word-wrap: break-word;
+    word-break: break-all;}


### PR DESCRIPTION
### 発言のスタイルを変更できるように
- `../iconlog.css` への参照を追加。タブ別のhtml出力でも一括でスタイルを指定できる。
- 発言者IDの列を追加。誰が発言したか区別できる。
- 発言者のIDを発言（行）のCSSクラスとして追加。発言者のIDをクラス名として指定することで、発言者毎の色分けなどができる。
- タブ名の列の開始タグ（td）を発言全体の開始タグ（tr）と同じ行に出力するように。全体ログで特定タブの発言の背景色などを指定したい時に一括置換がラク